### PR TITLE
.update-pots.py: store CPython sync commit hash in the commit message

### DIFF
--- a/.update-pots.py
+++ b/.update-pots.py
@@ -17,13 +17,13 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            heads_hash = _run('git -C cpython/ rev-parse HEAD')
+            cpython_commit = _run('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()
     if all_ := changed + added:
         _call(f'git add {" ".join(all_)}')
-        _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {heads_hash}"')
+        _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {cpython_commit}"')
     _call('git restore .')  # discard ignored files
 
 

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -19,7 +19,7 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            heads_hash = _run('git rev-parse HEAD')
+            heads_hash = _run('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -17,7 +17,7 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            cpython_commit = _run('git -C cpython/ rev-parse HEAD')
+            cpython_commit = _output('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -19,8 +19,8 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
+            heads_hash = _run('git rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
-        heads_hash = _run('git rev-parse HEAD')
     changed = _get_changed_pots()
     added = _get_new_pots()
     if all_ := changed + added:

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -11,9 +11,7 @@ from tempfile import TemporaryDirectory
 
 
 def _update_pots(version: str) -> None:
-    _call('git diff --exit-code')  # ensure clean git status
-    # TODO determine latest sync commit
-    # if latest sync commit not found, checkout the HEAD
+    _call('git diff --exit-code')  # ensure working tree clean
     with TemporaryDirectory() as directory:
         with chdir(directory):
             _clone_cpython_repo(version)


### PR DESCRIPTION
Adding a CPython repository commit hash for the state of generated POTs.

Ground for #7 in updating sources.