### PR TITLE
.update-pots.py: use check_call and check_output

### DIFF
--- a/.update-pots.py
+++ b/.update-pots.py
@@ -51,9 +51,8 @@ def _get_new_pots() -> list[str]:
     return ls_files.splitlines()
 
 
-def _call(command: str):
-    if (return_code := check_call(command, shell=True)) != 0:
-        exit(return_code)
+def _call(command: str) -> None:
+    check_call(command, shell=True)
 
 
 def _output(command: str) -> str:

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -6,7 +6,7 @@ from os import PathLike
 from pathlib import Path
 from re import match
 from shutil import move, rmtree
-from subprocess import call, run
+from subprocess import call, check_output
 from tempfile import TemporaryDirectory
 
 
@@ -42,12 +42,12 @@ def _replace_tree(source: PathLike, target: PathLike):
 
 
 def _get_changed_pots() -> list[str]:
-    diff = _run("git diff -I'^\"POT-Creation-Date: ' --numstat")
+    diff = _check_output("git diff -I'^\"POT-Creation-Date: ' --numstat")
     return [match(r'\d+\t\d+\t(.*)', line).group(1) for line in diff.splitlines()]
 
 
 def _get_new_pots() -> list[str]:
-    ls_files = _run('git ls-files -o -d --exclude-standard')
+    ls_files = _check_output('git ls-files -o -d --exclude-standard')
     return ls_files.splitlines()
 
 
@@ -56,10 +56,8 @@ def _call(command: str):
         exit(return_code)
 
 
-def _run(command: str) -> str:
-    if (process := run(command, shell=True, capture_output=True)).returncode != 0:
-        exit(process.returncode)
-    return process.stdout.decode()
+def _check_output(command: str) -> str:
+    return check_output(command, shell=True).decode()
 
 
 if __name__ == "__main__":

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -6,7 +6,7 @@ from os import PathLike
 from pathlib import Path
 from re import match
 from shutil import move, rmtree
-from subprocess import call, check_output
+from subprocess import check_call, check_output
 from tempfile import TemporaryDirectory
 
 
@@ -42,21 +42,21 @@ def _replace_tree(source: PathLike, target: PathLike):
 
 
 def _get_changed_pots() -> list[str]:
-    diff = _check_output("git diff -I'^\"POT-Creation-Date: ' --numstat")
+    diff = _output("git diff -I'^\"POT-Creation-Date: ' --numstat")
     return [match(r'\d+\t\d+\t(.*)', line).group(1) for line in diff.splitlines()]
 
 
 def _get_new_pots() -> list[str]:
-    ls_files = _check_output('git ls-files -o -d --exclude-standard')
+    ls_files = _output('git ls-files -o -d --exclude-standard')
     return ls_files.splitlines()
 
 
 def _call(command: str):
-    if (return_code := call(command, shell=True)) != 0:
+    if (return_code := check_call(command, shell=True)) != 0:
         exit(return_code)
 
 
-def _check_output(command: str) -> str:
+def _output(command: str) -> str:
     return check_output(command, shell=True).decode()
 
 


### PR DESCRIPTION
It raises exceptions for unsuccessful subprocess calls, so it's much more verbose then earlier (exit without stdout).

Example:
```
…

Traceback (most recent call last):
  File "/Users/maciej.olko/projects/python-docs-weblate/.update-pots.py", line 67, in <module>
    _update_pots(options.version)
  File "/Users/maciej.olko/projects/python-docs-weblate/.update-pots.py", line 14, in _update_pots
    _call('git diff --exit-code')
  File "/Users/maciej.olko/projects/python-docs-weblate/.update-pots.py", line 55, in _call
    check_call(command, shell=True)
  File "/Users/maciej.olko/.pyenv/versions/3.11-dev/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'git diff --exit-code' returned non-zero exit status 1.
```