### PR TITLE
Update POTs with commit messages from CPython repository

### DIFF
--- a/.update-pots.py
+++ b/.update-pots.py
@@ -40,6 +40,7 @@ def _update_pots(version: str) -> None:
                 try:
                     _call(f'git -C {directory}/cpython/ reset --hard HEAD@{1}')  # move one commit forward
                 except CalledProcessError:
+                    info("Already on repository's HEAD, breaking out of the loop")
                     break
 
     else:

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -30,12 +30,13 @@ def _update_pots(version: str) -> None:
                 with chdir(directory):
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
+                    commit_message = _output('git -C cpython log --pretty=format:"%B" --max-count=1')
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
                 changed = _get_changed_pots()
                 added = _get_new_pots()
                 if all_ := changed + added:
                     _call(f'git add {" ".join(all_)}')
-                    _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {cpython_commit}"')
+                    _call(f'git commit -m "{commit_message}\nCPython-sync-commit: {cpython_commit}"')
                 _call('git restore .')  # discard ignored files
                 try:
                     _call(f'git -C {directory}/cpython/ reset --hard HEAD@{1}')  # move one commit forward

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -2,6 +2,7 @@
 
 from argparse import ArgumentParser
 from contextlib import chdir
+from logging import info, basicConfig
 from os import PathLike
 from pathlib import Path
 from re import match
@@ -20,6 +21,7 @@ def _update_pots(version: str) -> None:
     if git_log:
         cpython_commit_line, *_ = git_log
         cpython_commit = cpython_commit_line.removeprefix('CPython-sync-commit: ')
+        info(f"Latest CPython sync commit found: {cpython_commit}")
         with TemporaryDirectory() as directory:
             with chdir(directory):
                 _clone_cpython_repo(version, shallow=False)
@@ -41,6 +43,7 @@ def _update_pots(version: str) -> None:
                     break
 
     else:
+        info("Latest CPython sync commit not found")
         # if latest sync commit not found, checkout the HEAD
         with TemporaryDirectory() as directory:
             with chdir(directory):
@@ -97,5 +100,7 @@ if __name__ == "__main__":
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('version')
     options = parser.parse_args()
+
+    basicConfig(level='INFO')
 
     _update_pots(options.version)

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -18,6 +18,7 @@ def _update_pots(version: str) -> None:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
                     _clone_cpython_repo(version, shallow=False)
+                    breakpoint()
                     _call(f'git -C cpython/ reset {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -25,13 +25,13 @@ def _update_pots(version: str) -> None:
         with TemporaryDirectory() as directory:
             with chdir(directory):
                 _clone_cpython_repo(version, shallow=False)
-                _call(f'git -C cpython/ reset --hard {cpython_commit}')
+                _call(f'git -C cpython/ checkout {cpython_commit}')
             while True:
                 with chdir(directory):
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
                     commit_message = _output('git -C cpython/ log --pretty=format:"%B" --max-count=1')
-                    cpython_commit = _output('git -C cpython/ rev-parse HEAD')
+                    cpython_commit = _output('git -C cpython/ log --pretty=format:"%H" --max-count=1')
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
                 changed = _get_changed_pots()
                 added = _get_new_pots()
@@ -40,7 +40,7 @@ def _update_pots(version: str) -> None:
                     _call(f'git commit -m "{commit_message}\nCPython-sync-commit: {cpython_commit}"')
                 _call('git restore .')  # discard ignored files
                 try:
-                    _call(f'git -C {directory}/cpython/ reset --hard HEAD@{{1}}')  # move one commit forward
+                    _call(f'git -C {directory}/cpython/ checkout HEAD@{{1}}')  # move one commit forward
                 except CalledProcessError:
                     info("Already on repository's HEAD, breaking out of the loop")
                     break

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -21,9 +21,9 @@ def _update_pots(version: str) -> None:
         with TemporaryDirectory() as directory:
             with chdir(directory):
                 _clone_cpython_repo(version, shallow=False)
+                _call(f'git -C cpython/ reset --hard {cpython_commit}')
             while True:
                 with chdir(directory):
-                    _call(f'git -C cpython/ reset --hard {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
@@ -34,7 +34,7 @@ def _update_pots(version: str) -> None:
                     _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {cpython_commit}"')
                 _call('git restore .')  # discard ignored files
                 try:
-                    _call('git reset --hard HEAD@{1}')  # move one commit forward
+                    _call(f'git -C {directory}/cpython/ reset --hard HEAD@{1}')  # move one commit forward
                 except CalledProcessError:
                     break
 

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -17,13 +17,13 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            heads_hash = _run('git -C cpython/ rev-parse HEAD')
+            cpython_commit = _run('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()
     if all_ := changed + added:
         _call(f'git add {" ".join(all_)}')
-        _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {heads_hash}"')
+        _call(f'git commit -m "Update sources\n\nCPython-sync-commit: {cpython_commit}"')
     _call('git restore .')  # discard ignored files
 
 

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -19,7 +19,7 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            heads_hash = _run('git rev-parse HEAD')
+            heads_hash = _run('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -1,4 +1,4 @@
-"""updates translation sources and commits them"""
+"""updates translation sources and commits them commit by commit from CPython repository"""
 
 from argparse import ArgumentParser
 from contextlib import chdir

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -18,7 +18,7 @@ def _update_pots(version: str) -> None:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
                     _clone_cpython_repo(version)
-                    _call(f'git reset {cpython_commit}')
+                    _call(f'git -C cpython/ reset {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -17,7 +17,7 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
-            cpython_commit = _run('git -C cpython/ rev-parse HEAD')
+            cpython_commit = _output('git -C cpython/ rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
     changed = _get_changed_pots()
     added = _get_new_pots()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -10,17 +10,19 @@ from shutil import move, rmtree
 from subprocess import check_call, check_output
 from tempfile import TemporaryDirectory
 
+SYNC_COMMIT_FIELD = 'CPython-sync-commit:'
+
 
 def _update_pots(version: str) -> None:
     _call('git diff --exit-code')  # ensure working tree clean
     sync_commit_lines = [
         line for line
-        in _output('git log --grep CPython-sync-commit: --pretty=format:"%B" --max-count=1').splitlines()
-        if line.startswith('CPython-sync-commit: ')
+        in _output(f'git log --grep {SYNC_COMMIT_FIELD} --pretty=format:"%B" --max-count=1').splitlines()
+        if line.startswith(SYNC_COMMIT_FIELD)
     ]
     if sync_commit_lines:
         cpython_commit_line, *_ = sync_commit_lines
-        cpython_commit = cpython_commit_line.removeprefix('CPython-sync-commit: ')
+        cpython_commit = cpython_commit_line.removeprefix(f'{SYNC_COMMIT_FIELD} ')
         info(f"Latest CPython sync commit found: {cpython_commit}")
         with TemporaryDirectory() as directory:
             with chdir(directory):
@@ -71,7 +73,7 @@ def _commit_changed(commit_message: str, commit: str) -> None:
     added = _get_new_pots()
     if all_ := changed + added:
         _call(f'git add {" ".join(all_)}')
-        _call(f'git commit -m "{commit_message}\n\nCPython-sync-commit: {commit}"')
+        _call(f'git commit -m "{commit_message}\n\n{SYNC_COMMIT_FIELD} {commit}"')
     _call('git restore .')  # discard ignored files
 
 

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -17,7 +17,7 @@ def _update_pots(version: str) -> None:
         while True:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
-                    _clone_cpython_repo(version)
+                    _clone_cpython_repo(version, shallow=False)
                     _call(f'git -C cpython/ reset {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
@@ -34,7 +34,7 @@ def _update_pots(version: str) -> None:
         # if latest sync commit not found, checkout the HEAD
         with TemporaryDirectory() as directory:
             with chdir(directory):
-                _clone_cpython_repo(version)
+                _clone_cpython_repo(version, shallow=True)
                 _call('make -C cpython/Doc/ venv')
                 _build_gettext()
                 cpython_commit = _output('git -C cpython/ rev-parse HEAD')
@@ -47,8 +47,11 @@ def _update_pots(version: str) -> None:
         _call('git restore .')  # discard ignored files
 
 
-def _clone_cpython_repo(version: str):
-    _call(f'git clone -b {version} --single-branch https://github.com/python/cpython.git --depth 1')
+def _clone_cpython_repo(version: str, shallow: bool):
+    _call(
+        f'git clone -b {version} --single-branch https://github.com/python/cpython.git'
+        + ' --depth 1' if shallow else ''
+    )
 
 
 def _build_gettext():

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -12,13 +12,16 @@ from tempfile import TemporaryDirectory
 
 def _update_pots(version: str) -> None:
     _call('git diff --exit-code')  # ensure working tree clean
-    cpython_commit = _output('git log --grep CPython-sync-commit: --pretty=format:"%H" --max-count=1')
+    cpython_commit = [
+        line for line
+        in _output('git log --grep CPython-sync-commit: --pretty=format:"%B" --max-count=1').splitlines()
+        if line.startswith('CPython-sync-commit: ')
+    ][0].removeprefix('CPython-sync-commit: ')
     if cpython_commit:
         while True:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
                     _clone_cpython_repo(version, shallow=False)
-                    breakpoint()
                     _call(f'git -C cpython/ reset {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -21,7 +21,7 @@ def _update_pots(version: str) -> None:
         while True:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
-                    _clone_cpython_repo(version)
+                    _clone_cpython_repo(version, shallow=False)
                     _call(f'git -C cpython/ reset --hard {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
@@ -41,7 +41,7 @@ def _update_pots(version: str) -> None:
         # if latest sync commit not found, checkout the HEAD
         with TemporaryDirectory() as directory:
             with chdir(directory):
-                _clone_cpython_repo(version)
+                _clone_cpython_repo(version, shallow=True)
                 _call('make -C cpython/Doc/ venv')
                 _build_gettext()
                 cpython_commit = _output('git -C cpython/ rev-parse HEAD')
@@ -54,8 +54,11 @@ def _update_pots(version: str) -> None:
         _call('git restore .')  # discard ignored files
 
 
-def _clone_cpython_repo(version: str):
-    _call(f'git clone -b {version} --single-branch https://github.com/python/cpython.git --depth 1')
+def _clone_cpython_repo(version: str, shallow: bool):
+    _call(
+        f'git clone -b {version} --single-branch https://github.com/python/cpython.git'
+        + (' --depth 1' if shallow else '')
+    )
 
 
 def _build_gettext():

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -19,8 +19,8 @@ def _update_pots(version: str) -> None:
             _clone_cpython_repo(version)
             _call('make -C cpython/Doc/ venv')
             _build_gettext()
+            heads_hash = _run('git rev-parse HEAD')
         _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
-        heads_hash = _run('git rev-parse HEAD')
     changed = _get_changed_pots()
     added = _get_new_pots()
     if all_ := changed + added:

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -18,7 +18,6 @@ def _update_pots(version: str) -> None:
             with TemporaryDirectory() as directory:
                 with chdir(directory):
                     _clone_cpython_repo(version, shallow=False)
-                    breakpoint()
                     _call(f'git -C cpython/ reset {cpython_commit}')
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
@@ -51,7 +50,7 @@ def _update_pots(version: str) -> None:
 def _clone_cpython_repo(version: str, shallow: bool):
     _call(
         f'git clone -b {version} --single-branch https://github.com/python/cpython.git'
-        + ' --depth 1' if shallow else ''
+        + (' --depth 1' if shallow else '')
     )
 
 

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -25,6 +25,7 @@ def _update_pots(version: str) -> None:
         with TemporaryDirectory() as directory:
             with chdir(directory):
                 _clone_cpython_repo(version, shallow=False)
+                cpython_head = _output('git -C cpython/ rev-parse HEAD')
                 _call(f'git -C cpython/ checkout {cpython_commit}')
             while True:
                 with chdir(directory):
@@ -39,11 +40,10 @@ def _update_pots(version: str) -> None:
                     _call(f'git add {" ".join(all_)}')
                     _call(f'git commit -m "{commit_message}\nCPython-sync-commit: {cpython_commit}"')
                 _call('git restore .')  # discard ignored files
-                try:
-                    _call(f'git -C {directory}/cpython/ checkout HEAD@{{1}}')  # move one commit forward
-                except CalledProcessError:
+                if cpython_commit == cpython_head:
                     info("Already on repository's HEAD, breaking out of the loop")
                     break
+                _call(f'git -C {directory}/cpython/ checkout HEAD@{{1}}')  # move one commit forward
 
     else:
         info("Latest CPython sync commit not found")

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -30,7 +30,7 @@ def _update_pots(version: str) -> None:
                 with chdir(directory):
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
-                    commit_message = _output('git -C cpython log --pretty=format:"%B" --max-count=1')
+                    commit_message = _output('git -C cpython/ log --pretty=format:"%B" --max-count=1')
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
                 changed = _get_changed_pots()
                 added = _get_new_pots()
@@ -39,7 +39,7 @@ def _update_pots(version: str) -> None:
                     _call(f'git commit -m "{commit_message}\nCPython-sync-commit: {cpython_commit}"')
                 _call('git restore .')  # discard ignored files
                 try:
-                    _call(f'git -C {directory}/cpython/ reset --hard HEAD@{1}')  # move one commit forward
+                    _call(f'git -C {directory}/cpython/ reset --hard HEAD@{{1}}')  # move one commit forward
                 except CalledProcessError:
                     info("Already on repository's HEAD, breaking out of the loop")
                     break

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -12,12 +12,14 @@ from tempfile import TemporaryDirectory
 
 def _update_pots(version: str) -> None:
     _call('git diff --exit-code')  # ensure working tree clean
-    cpython_commit = [
+    git_log = [
         line for line
         in _output('git log --grep CPython-sync-commit: --pretty=format:"%B" --max-count=1').splitlines()
         if line.startswith('CPython-sync-commit: ')
-    ][0].removeprefix('CPython-sync-commit: ')
-    if cpython_commit:
+    ]
+    if git_log:
+        cpython_commit_line, *_ = git_log
+        cpython_commit = cpython_commit_line.removeprefix('CPython-sync-commit: ')
         with TemporaryDirectory() as directory:
             with chdir(directory):
                 _clone_cpython_repo(version, shallow=False)

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -11,9 +11,7 @@ from tempfile import TemporaryDirectory
 
 
 def _update_pots(version: str) -> None:
-    _call('git diff --exit-code')  # ensure clean git status
-    # TODO determine latest sync commit
-    # if latest sync commit not found, checkout the HEAD
+    _call('git diff --exit-code')  # ensure working tree clean
     with TemporaryDirectory() as directory:
         with chdir(directory):
             _clone_cpython_repo(version)

--- a/.update-pots.py
+++ b/.update-pots.py
@@ -31,6 +31,7 @@ def _update_pots(version: str) -> None:
                     _call('make -C cpython/Doc/ venv')
                     _build_gettext()
                     commit_message = _output('git -C cpython/ log --pretty=format:"%B" --max-count=1')
+                    cpython_commit = _output('git -C cpython/ rev-parse HEAD')
                 _replace_tree(Path(directory, 'cpython/Doc/locales/pot'), '.pot')
                 changed = _get_changed_pots()
                 added = _get_new_pots()


### PR DESCRIPTION
For each commit in CPython repository that modifies documentation, commit a source change in the local repository with the original commit message.

Refs #7.

Tested locally.

* [x] update module docstring